### PR TITLE
Fix some typos in the examples of the Testing section

### DIFF
--- a/src/core_concepts/testing.md
+++ b/src/core_concepts/testing.md
@@ -151,6 +151,7 @@ async fn test_cross_chain_message() {
             block.with_operation(
                 application_id,
                 Operation::SendMessageTo(receiver_chain.id()),
+            )
         })
         .await;
 


### PR DESCRIPTION
There were some typos in the examples inside the Testing section that made the code invalid.