### PR TITLE
Update documentation to include latest SDK changes

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           mdbook-version: 'latest'
 
+      - name: 'Install Protoc'
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: 'Build the Linera SDK'
         run: |
           cd linera-protocol

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -32,6 +32,7 @@
 
   - [Views](advanced_topics/views.md)
   - [Persistent Storage](advanced_topics/persistent_storage.md)
+  - [Contract Finalization](advanced_topics/contract_finalize.md)
   - [Validators](advanced_topics/validators.md)
   - [Creating New Blocks](advanced_topics/block_creation.md)
 

--- a/src/advanced_topics/contract_finalize.md
+++ b/src/advanced_topics/contract_finalize.md
@@ -22,11 +22,10 @@ other applications, because they are all also finalizing.
 > the developer must ensure that the application's state is persisted correctly.
 
 While finalizing, contracts can force the transaction to fail by panicking or
-returning an error. The block is then rejected, even if the entire
-transaction's operation had succeeded before `finalize` was called. This allows
-a contract to reject transactions if other applications don't follow any
-required constraints it establishes after it responds to a cross-application
-call.
+returning an error. The block is then rejected, even if the entire transaction's
+operation had succeeded before `finalize` was called. This allows a contract to
+reject transactions if other applications don't follow any required constraints
+it establishes after it responds to a cross-application call.
 
 As an example, a contract that executes a cross-application call with
 `Operation::StartSession` may require the same caller to perform another

--- a/src/advanced_topics/contract_finalize.md
+++ b/src/advanced_topics/contract_finalize.md
@@ -1,0 +1,107 @@
+# Contract Finalization
+
+When a transaction finishes executing successfully, there's a final step where
+all loaded application contracts are allowed to `finalize`, similarly to
+executing a destructor. The default implementation of `finalize` just persists
+the application's state:
+
+```rust,ignore
+    /// Finishes the execution of the current transaction.
+    async fn finalize(&mut self) -> Result<(), Self::Error> {
+        Self::Storage::store(self.state_mut()).await;
+        Ok(())
+    }
+```
+
+Applications may want to override the `finalize` method, which allows performing
+some clean-up operations after execution finished. While finalizing, contracts
+may send messages, read and write to the state, but are not allowed to call
+other applications, because they are all also finalizing.
+
+> If `finalize` is overriden, the default implementation is **not** executed, so
+> the developer must ensure that the application's state is persisted correctly.
+
+While finalizing, contracts can force the transaction to fail by panicking or
+returning an error. The block is then rejected, even if the entire
+transaction's operation had succeeded before `finalize` was called. This allows
+a contract to reject transactions if other applications don't follow any
+required constraints it establishes after it responds to a cross-application
+call.
+
+As an example, a contract that executes a cross-application call with
+`Operation::StartSession` may require the same caller to perform another
+cross-application call with `Operation::EndSession` before the transaction ends.
+
+```rust,ignore
+pub struct MyContract {
+    state: MyState;
+    runtime: ContractRuntime<Self>;
+    active_sessions: HashSet<ApplicationId>;
+}
+
+#[async_trait]
+impl Contract for MyContract {
+    type Error = MyError;
+    type State = MyState;
+    type Storage = ViewStateStorage<Self>;
+    type Message = ();
+
+    async fn new(state: Self::State, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {
+        MyContract {
+            state,
+            runtime,
+            active_sessions: HashSet::new(),
+        }
+    }
+
+    fn state_mut(&mut self) -> &mut Self::State {
+        &mut self.state
+    }
+
+    async fn initialize(
+        &mut self,
+        argument: Self::InitializationArgument,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn execute_operation(
+        &mut self,
+        operation: Self::Operation,
+    ) -> Result<Self::Response, Self::Error> {
+        let caller = self.runtime
+            .authenticated_caller_id()
+            .expect("Missing caller ID");
+
+        match operation {
+            Operation::StartSession => {
+                assert!(
+                    self.active_sessions.insert(caller_id),
+                    "Can't start more than one session for the same caller"
+                );
+            }
+            Operation::EndSession => {
+                assert!(
+                    self.active_sessions.remove(&caller_id),
+                    "Session was not started"
+                );
+            }
+        }
+    }
+
+    async fn execute_message(&mut self, message: Self::Message) -> Result<(), Self::Error> {
+        unreachable!("This example doesn't support messages");
+    }
+
+    async fn finalize(&mut self) -> Result<(), Self::Error> {
+        assert!(
+            self.active_sessions.is_empty(),
+            "Some sessions have not ended"
+        );
+
+        Self::Storage::store(self.state_mut()).await;
+
+        Ok(())
+    }
+}
+```

--- a/src/appendix/glossary.md
+++ b/src/appendix/glossary.md
@@ -74,9 +74,10 @@
 - **Network**: The totality of all protocol participants. A network is the
   combination of committee, clients and auditors.
 
-- **Operation**: Operations are transactions directly added to a block by the
-  creator (and signer) of the block. Users typically use operations to start
-  interacting with an application on their own chain.
+- **Operation**: Operations are either transactions directly added to a block by
+  the creator (and signer) of the block, or calls to an application from
+  another. Users typically use operations to start interacting with an
+  application on their own chain.
 
 - **Permissioned Chain**: A microchain which is owned by more than one user.
   Users take turns proposing blocks and the likelihood of selection is

--- a/src/core_concepts/applications.md
+++ b/src/core_concepts/applications.md
@@ -113,14 +113,14 @@ pub enum Message {
 
 ### Authentication
 
-Operations in a block are always authenticated and messages may be authenticated.
-The signer of a block becomes the authenticator of all the operations in that
-block. As operations are being executed by applications, messages can be created
-to be sent to other chains. When they are created, they can be configured to be
-authenticated. In that case, the message receives the same authentication as the
-operation that created it. If handling an incoming message creates new messages,
-those may also be configured to have the same authentication as the received
-message.
+Operations in a block are always authenticated and messages may be
+authenticated. The signer of a block becomes the authenticator of all the
+operations in that block. As operations are being executed by applications,
+messages can be created to be sent to other chains. When they are created, they
+can be configured to be authenticated. In that case, the message receives the
+same authentication as the operation that created it. If handling an incoming
+message creates new messages, those may also be configured to have the same
+authentication as the received message.
 
 In other words, the block signer can have its authority propagated across chains
 through series of messages. This allows applications to safely store user state

--- a/src/core_concepts/applications.md
+++ b/src/core_concepts/applications.md
@@ -70,7 +70,8 @@ have a completely different set of operations. Chain owners then actively create
 operations and put them in their block proposals to interact with an
 application. Other applications may also call the application by providing an
 operation for it to execute, this is called a cross-application call and always
-happens within the same chain.
+happens within the same chain. Operations for cross-application calls may return
+a response value back to the caller.
 
 Taking the "fungible token" application as an example, an operation for a user
 to transfer funds to another user would look like this:

--- a/src/core_concepts/applications.md
+++ b/src/core_concepts/applications.md
@@ -112,10 +112,10 @@ pub enum Message {
 
 ### Authentication
 
-Operations are always authenticated and messages may be authenticated. The
-signer of a block becomes the authenticator of all the operations in that block.
-As operations are being executed by applications, messages can be created to be
-sent to other chains. When they are created, they can be configured to be
+Operations in a block are always authenticated and messages may be authenticated.
+The signer of a block becomes the authenticator of all the operations in that
+block. As operations are being executed by applications, messages can be created
+to be sent to other chains. When they are created, they can be configured to be
 authenticated. In that case, the message receives the same authentication as the
 operation that created it. If handling an incoming message creates new messages,
 those may also be configured to have the same authentication as the received

--- a/src/core_concepts/applications.md
+++ b/src/core_concepts/applications.md
@@ -68,7 +68,9 @@ and messages.
 **Operations** are defined by an application developer and each application can
 have a completely different set of operations. Chain owners then actively create
 operations and put them in their block proposals to interact with an
-application.
+application. Other applications may also call the application by providing an
+operation for it to execute, this is called a cross-application call and always
+happens within the same chain.
 
 Taking the "fungible token" application as an example, an operation for a user
 to transfer funds to another user would look like this:

--- a/src/core_concepts/applications.md
+++ b/src/core_concepts/applications.md
@@ -9,9 +9,9 @@ Currently, the [Linera SDK](../sdk.md) is focused on the
 
 Linera applications are structured using the familiar notion of **Rust crate**:
 the external interfaces of an application (including initialization parameters,
-operations, messages, and cross-application calls) generally go into the library
-part of its crate, while the core of each application is compiled into binary
-files for the Wasm architecture.
+operations and messages) generally go into the library part of its crate, while
+the core of each application is compiled into binary files for the Wasm
+architecture.
 
 ## The Application Deployment Lifecycle
 

--- a/src/core_concepts/overview.md
+++ b/src/core_concepts/overview.md
@@ -172,7 +172,6 @@ as follows.
 - [x] Support for the Wasmtime VM (experimental)
 - [x] Test gas metering and deterministic execution across VMs
 - [x] Composing Wasm applications on the same chain (initial version)
-- [x] Enhanced composability with "sessions"
 - [x] Support for non-blocking (yet deterministic) calls to storage
 - [x] Support for read-only GraphQL services in Wasm
 - [x] Support for mocked system APIs (initial version)

--- a/src/sdk/abi.md
+++ b/src/sdk/abi.md
@@ -52,11 +52,8 @@ impl ContractAbi for CounterAbi {
     type InitializationArgument = u64;
     type Parameters = ();
     type Operation = u64;
-    type ApplicationCall = ();
-    type Message = ();
-    type SessionCall = ();
     type Response = ();
-    type SessionState = ();
+    type Message = ();
 }
 ```
 

--- a/src/sdk/abi.md
+++ b/src/sdk/abi.md
@@ -53,7 +53,6 @@ impl ContractAbi for CounterAbi {
     type Parameters = ();
     type Operation = u64;
     type Response = ();
-    type Message = ();
 }
 ```
 

--- a/src/sdk/contract.md
+++ b/src/sdk/contract.md
@@ -63,7 +63,7 @@ methods.
 
 To implement the application contract, we first create a type for the contract:
 
-```rust
+```rust,ignore
 pub struct CounterContract {
     state: Counter,
     runtime: ContractRuntime<Self>,

--- a/src/sdk/contract.md
+++ b/src/sdk/contract.md
@@ -21,7 +21,7 @@ pub trait Contract: WithContractAbi + ContractAbi + Send + Sized {
     /// The type of message executed by the application.
     type Message: Serialize + DeserializeOwned + Send + Sync + Debug + 'static;
 
-    /// Creates a in-memory instance of the contract handler from the application's `state`.
+    /// Creates an in-memory instance of the contract handler from the application's `state`.
     async fn new(state: Self::State, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error>;
 
     /// Returns the current state of the application so that it can be persisted.

--- a/src/sdk/contract.md
+++ b/src/sdk/contract.md
@@ -101,7 +101,7 @@ through the `state_mut` method:
 ```
 
 Applications may want to override the `finalize` method in more advanced
-scenarios, but they must ensure they don't forget to *persist* their state if
+scenarios, but they must ensure they don't forget to _persist_ their state if
 they do so. For more information see the
 [Contract finalization section](../advanced_topics/contract_finalize.md).
 

--- a/src/sdk/contract.md
+++ b/src/sdk/contract.md
@@ -133,22 +133,18 @@ using its initialization parameters:
 ## Implementing the Increment Operation
 
 Now that we have our counter's state and a way to initialize it to any value we
-would like, a way to increment our counter's value. Changes made by block
-proposers to application states are broadly called 'operations'.
+would like, we need a way to increment our counter's value. Execution requests
+from block proposers or other applications are broadly called 'operations'.
 
 To create a new operation, we need to use the method
 `Contract::execute_operation`. In the counter's case, it will be receiving a
 `u64` which is used to increment the counter:
 
 ```rust,ignore
-    async fn execute_operation(
-        &mut self,
-        _context: &OperationContext,
-        operation: u64,
-    ) -> Result<ExecutionOutcome<Self::Message>, Self::Error> {
+    async fn execute_operation(&mut self, operation: u64) -> Result<(), Self::Error> {
         let current = self.value.get();
         self.value.set(current + operation);
-        Ok(ExecutionOutcome::default())
+        Ok(())
     }
 ```
 

--- a/src/sdk/contract.md
+++ b/src/sdk/contract.md
@@ -108,8 +108,9 @@ they do so. For more information see the
 
 ## Initializing our Application
 
-The first thing we need to do is initialize our application by using
-`Contract::initialize`.
+The first thing that happens when an application is created from a bytecode is
+that it is initialized. This is done by calling the contract handler's
+`Contract::initialize` method.
 
 `Contract::initialize` is only called once when the application is created and
 only on the microchain that created the application.
@@ -123,13 +124,9 @@ application to an arbitrary number that can be specified on application creation
 using its initialization parameters:
 
 ```rust,ignore
-    async fn initialize(
-        &mut self,
-        _context: &OperationContext,
-        value: u64,
-    ) -> Result<ExecutionOutcome<Self::Message>, Self::Error> {
-        self.value.set(value);
-        Ok(ExecutionOutcome::default())
+    async fn initialize(&mut self, value: u64) -> Result<(), Self::Error> {
+        self.state.value.set(value);
+        Ok(())
     }
 ```
 

--- a/src/sdk/contract.md
+++ b/src/sdk/contract.md
@@ -154,7 +154,7 @@ Finally, to link our `Contract` trait implementation with the ABI of the
 application, the following code is added:
 
 ```rust,ignore
-impl WithContractAbi for Counter {
+impl WithContractAbi for CounterContract {
     type Abi = counter::CounterAbi;
 }
 ```

--- a/src/sdk/contract.md
+++ b/src/sdk/contract.md
@@ -102,7 +102,7 @@ through the `state_mut` method:
 ```
 
 Applications may want to override the `finalize` method in more advanced
-scenarios, but they must ensure the don't forget to *persist* their state if
+scenarios, but they must ensure they don't forget to *persist* their state if
 they do so. For more information see the
 [Contract finalization section](../advanced_topics/contract_finalize.md).
 

--- a/src/sdk/contract.md
+++ b/src/sdk/contract.md
@@ -59,10 +59,9 @@ a time.
 For this application, we'll be using the `initialize` and `execute_operation`
 methods.
 
-## The Contract handler lifecycle
+## The Contract Lifecycle
 
-To implement the application contract, we first create a type to be the contract
-handler:
+To implement the application contract, we first create a type for the contract:
 
 ```rust
 pub struct CounterContract {
@@ -79,9 +78,9 @@ that only exists while the current transaction is being executed, and discarded
 afterwards.
 
 When a transaction is executed, first the application's state is loaded, then
-the contract handler type is created by calling the `Contract::new` method. This
-method receives the state and a handle to the runtime that the contract handler
-can use. For our implementation, we will just store the received parameters:
+the contract type is created by calling the `Contract::new` method. This method
+receives the state and a handle to the runtime that the contract can use. For
+our implementation, we will just store the received parameters:
 
 ```rust,ignore
     async fn new(state: Counter, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {
@@ -109,7 +108,7 @@ they do so. For more information see the
 ## Initializing our Application
 
 The first thing that happens when an application is created from a bytecode is
-that it is initialized. This is done by calling the contract handler's
+that it is initialized. This is done by calling the contract's
 `Contract::initialize` method.
 
 `Contract::initialize` is only called once when the application is created and

--- a/src/sdk/messages.md
+++ b/src/sdk/messages.md
@@ -31,7 +31,7 @@ is specify a
 [`ChannelName`](https://docs.rs/linera-base/latest/linera_base/identifiers/struct.ChannelName.html)
 as the destination parameter to `send_to`.
 
-During block execution in the _sending_ chain, sent messages are placed in the
+After block execution in the _sending_ chain, sent messages are placed in the
 _target_ chains' inboxes for processing. There is no guarantee that it will be
 handled: For this to happen, an owner of the target chain needs to include it
 in the `incoming_messages` in one of their blocks. When that happens, the

--- a/src/sdk/messages.md
+++ b/src/sdk/messages.md
@@ -9,37 +9,47 @@ handling code is guaranteed to be the same as the sending code, but the state
 may be different.
 
 For your application, you can specify any serializable type as the `Message`
-type in your `ContractAbi` implementation. To send a message, return it among
-the
-[`ExecutionOutcome`](https://docs.rs/linera-sdk/latest/linera_sdk/struct.ExecutionOutcome.html)'s
-`messages`:
+type in your `ContractAbi` implementation. To send a message, use the
+[`ContractRuntime`](https://docs.rs/linera-sdk/latest/linera_sdk/struct.ContractRuntime.html)
+made available as an argument to the contract handler's [`Contract::new`]
+constructor. The runtime is usually stored inside the contract handler object,
+as we did when [writing the contract binary](./contract.md). We can then call
+[`ContractRuntime::prepare_message`](https://docs.rs/linera-sdk/latest/linera_sdk/struct.ContractRuntime.html#prepare_message)
+to start preparing a message, and then
+[`send_to`](https://docs.rs/linera-sdk/latest/linera_sdk/struct.MessageBuilder.html#send_to)
+to send it to a destination chain.
 
 ```rust,ignore
-    pub messages: Vec<OutgoingMessage<Message>>,
+    self.runtime
+        .prepare_message(message_contents)
+        .send_to(destination_chain_id);
 ```
 
-`OutgoingMessage`'s `destination` field specifies either a single destination
-chain, or a channel, so that it gets sent to all subscribers.
+It is also possible to send a message to a subscription channel, so that the
+message is forwarded to the subscribers of that channel. All that has to be done
+is specify a
+[`ChannelName`](https://docs.rs/linera-base/latest/linera_base/identifiers/struct.ChannelName.html)
+as the destination parameter to `send_to`.
 
-If the `authenticated` field is `true`, the callee is allowed to perform actions
-that require authentication on behalf of the signer of the original block that
-caused this call.
+During block execution in the _sending_ chain, sent messages are placed in the
+_target_ chains' inboxes for processing. There is no guarantee that it will be
+handled: For this to happen, an owner of the target chain needs to include it
+in the `incoming_messages` in one of their blocks. When that happens, the
+contract's `execute_message` method gets called on their chain.
 
-The `message` field contains the message itself, of the type you specified in
-the `ContractAbi`.
+While preparing the message to be sent, it is possible to enable authentication
+forwarding and/or tracking. Authentication forwarding means that the message is
+executed with the same authenticated signer as the sender of the message, while
+tracking means that the message is sent back to the sender if the receiver
+skips it. The example below enables both flags:
 
-You can also use
-[`ExecutionOutcome::with_message`](https://docs.rs/linera-sdk/latest/linera_sdk/struct.ExecutionOutcome.html#method.with_message)
-and
-[`with_authenticated_message`](https://docs.rs/linera-sdk/latest/linera_sdk/struct.ExecutionOutcome.html#method.with_authenticated_message)
-for convenience.
-
-During block execution in the _sending_ chain, messages are returned via
-`ExecutionOutcome`s. The returned message is then placed in the _target_ chain
-inbox for processing. There is no guarantee that it will be handled: For this to
-happen, an owner of the target chain needs to include it in the
-`incoming_messages` in one of their blocks. When that happens, the contract's
-`execute_message` method gets called on their chain.
+```rust,ignore
+    self.runtime
+        .prepare_message(message_contents)
+        .with_tracking()
+        .with_authentication()
+        .send_to(destination_chain_id);
+```
 
 ## Example: Fungible Token
 
@@ -52,24 +62,43 @@ account balance and sends a `Credit` message to the recipient's chain:
 ```rust,ignore
 async fn execute_operation(
     &mut self,
-    context: &OperationContext,
     operation: Self::Operation,
-) -> Result<ExecutionOutcome<Self::Message>, Self::Error> {
+) -> Result<Self::Response, Self::Error> {
     match operation {
+        // ...
         Operation::Transfer {
             owner,
             amount,
             target_account,
         } => {
-            // ...
-            self.debit(owner, amount).await?;
-            let message = Message::Credit {
-                owner: target_account.owner,
-                amount,
-            };
-            Ok(ExecutionOutcome::default().with_message(target_account.chain_id, message))
+            self.check_account_authentication(owner)?;
+            self.state.debit(owner, amount).await?;
+            self.finish_transfer_to_account(amount, target_account, owner)
+                .await;
+            Ok(FungibleResponse::Ok)
         }
         // ...
+    }
+}
+
+async fn finish_transfer_to_account(
+    &mut self,
+    amount: Amount,
+    target_account: Account,
+    source: AccountOwner,
+) {
+    if target_account.chain_id == self.runtime.chain_id() {
+        self.state.credit(target_account.owner, amount).await;
+    } else {
+        let message = Message::Credit {
+            target: target_account.owner,
+            amount,
+            source,
+        };
+        self.runtime
+            .prepare_message(message)
+            .with_authentication()
+            .send_to(target_account.chain_id);
     }
 }
 ```
@@ -78,17 +107,19 @@ On the recipient's chain, `execute_message` is called, which increases their
 account balance.
 
 ```rust,ignore
-async fn execute_message(
-    &mut self,
-    context: &MessageContext,
-    message: Message,
-) -> Result<ExecutionOutcome<Self::Message>, Self::Error> {
+async fn execute_message(&mut self, message: Message) -> Result<(), Self::Error> {
     match message {
-        Message::Credit { owner, amount } => {
-            self.credit(owner, amount).await;
-            Ok(ExecutionOutcome::default())
+        Message::Credit {
+            amount,
+            target,
+            source,
+        } => {
+            // ...
+            self.state.credit(receiver, amount).await;
         }
         // ...
     }
+
+    Ok(())
 }
 ```

--- a/src/sdk/messages.md
+++ b/src/sdk/messages.md
@@ -11,9 +11,9 @@ may be different.
 For your application, you can specify any serializable type as the `Message`
 type in your `ContractAbi` implementation. To send a message, use the
 [`ContractRuntime`](https://docs.rs/linera-sdk/latest/linera_sdk/struct.ContractRuntime.html)
-made available as an argument to the contract handler's [`Contract::new`]
-constructor. The runtime is usually stored inside the contract handler object,
-as we did when [writing the contract binary](./contract.md). We can then call
+made available as an argument to the contract's [`Contract::new`] constructor.
+The runtime is usually stored inside the contract object, as we did when
+[writing the contract binary](./contract.md). We can then call
 [`ContractRuntime::prepare_message`](https://docs.rs/linera-sdk/latest/linera_sdk/struct.ContractRuntime.html#prepare_message)
 to start preparing a message, and then
 [`send_to`](https://docs.rs/linera-sdk/latest/linera_sdk/struct.MessageBuilder.html#send_to)

--- a/src/sdk/messages.md
+++ b/src/sdk/messages.md
@@ -33,15 +33,15 @@ as the destination parameter to `send_to`.
 
 After block execution in the _sending_ chain, sent messages are placed in the
 _target_ chains' inboxes for processing. There is no guarantee that it will be
-handled: For this to happen, an owner of the target chain needs to include it
-in the `incoming_messages` in one of their blocks. When that happens, the
+handled: For this to happen, an owner of the target chain needs to include it in
+the `incoming_messages` in one of their blocks. When that happens, the
 contract's `execute_message` method gets called on their chain.
 
 While preparing the message to be sent, it is possible to enable authentication
 forwarding and/or tracking. Authentication forwarding means that the message is
 executed with the same authenticated signer as the sender of the message, while
-tracking means that the message is sent back to the sender if the receiver
-skips it. The example below enables both flags:
+tracking means that the message is sent back to the sender if the receiver skips
+it. The example below enables both flags:
 
 ```rust,ignore
     self.runtime

--- a/src/sdk/service.md
+++ b/src/sdk/service.md
@@ -66,7 +66,7 @@ first step is to define the `Service`'s associated types:
 
 ```rust,ignore
 #[async_trait]
-impl Service for Counter {
+impl Service for CounterService {
     type Error = Error;
     type Storage = ViewStateStorage<Self>;
     type State = Counter;

--- a/src/sdk/service.md
+++ b/src/sdk/service.md
@@ -54,8 +54,8 @@ them, so in this example we're omitting the `runtime` field.
 We need to generate the necessary boilerplate for implementing the service
 [WIT interface](https://component-model.bytecodealliance.org/design/wit.html),
 export the necessary resource types and functions so that the service can be
-executed. Fortunately, there is a macro to perform this code generation, so
-just add the following to `service.rs`:
+executed. Fortunately, there is a macro to perform this code generation, so just
+add the following to `service.rs`:
 
 ```rust,ignore
 linera_sdk::service!(CounterService);

--- a/src/sdk/service.md
+++ b/src/sdk/service.md
@@ -39,7 +39,7 @@ The full service trait definition can be found
 
 Let's implement `Service` for our counter application.
 
-First, we create a new type for the service handler, similarly to the contract handler:
+First, we create a new type for the service, similarly to the contract:
 
 ```rust,ignore
 pub struct CounterService {


### PR DESCRIPTION
# Motivation

The SDK went through some big changes recently, and the documentation became out-of-date.

# Solution

Update the documentation to:

- use the new `ContractRuntime` type
- remove sessions
- replace `handle_application_call` with `execute_operation`
- remove context parameters
- remove outcome result types
- use separate types for contracts and services
- describe the `Contract::finalize` entrypoint