### PR TITLE
Suggest `cargo install --locked`

### DIFF
--- a/src/getting_started/installation.md
+++ b/src/getting_started/installation.md
@@ -59,8 +59,8 @@ This manual was tested with the following Rust toolchain:
 You may install the Linera binaries with
 
 ```bash
-cargo install linera-sdk@{{#include ../../RELEASE_VERSION}}
-cargo install linera-service@{{#include ../../RELEASE_VERSION}}
+cargo install --locked linera-sdk@{{#include ../../RELEASE_VERSION}}
+cargo install --locked linera-service@{{#include ../../RELEASE_VERSION}}
 ```
 
 and use `linera-sdk` as a library for Linera Wasm applications:
@@ -85,8 +85,8 @@ git checkout -t origin/{{#include ../../RELEASE_BRANCH}}  # Current release bran
 To install the Linera toolchain locally from source, you may run:
 
 ```bash
-cargo install --path linera-sdk
-cargo install --path linera-service
+cargo install --locked --path linera-sdk
+cargo install --locked --path linera-service
 ```
 
 Alternatively, for developing and debugging, you may instead use the binaries

--- a/src/sdk/testing.md
+++ b/src/sdk/testing.md
@@ -109,7 +109,7 @@ mod tests {
 Running `linera project test` is easier, but if there's a need to run
 `cargo test` explicitly to run the unit tests, Cargo must be configured to use
 the custom test runner `linera-wasm-test-runner`. This binary can be built from
-the repository or installed with `cargo install linera-sdk`.
+the repository or installed with `cargo install --locked linera-sdk`.
 
 ```bash
 cd linera-protocol


### PR DESCRIPTION
This is temporary until https://github.com/linera-io/linera-protocol/pull/2012 is included in the latest SDK release.