### PR TITLE
Added preliminary Docker Compose docs

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -46,6 +46,7 @@
 - [Operators](operators.md)
 
   - [Devnets](operators/devnets.md)
+    - [Docker Compose](operators/devnets/compose.md)
     - [kind](operators/devnets/kind.md)
 
 - [Appendix](appendix.md)

--- a/src/developers/sdk/messages.md
+++ b/src/developers/sdk/messages.md
@@ -53,7 +53,8 @@ receiver rejects it. The example below enables both flags:
 
 ## Example: Fungible Token
 
-In the [`fungible` example
+In the [`fungible`
+example
 application](https://github.com/linera-io/linera-protocol/tree/{{#include
 ../../../.git/modules/linera-protocol/HEAD}}/examples/fungible), such a message
 can be the transfer of tokens from one chain to another. If the sender includes

--- a/src/developers/sdk/service.md
+++ b/src/developers/sdk/service.md
@@ -152,6 +152,5 @@ impl MutationRoot {
 We haven't included the imports in the above code; they are left as an exercise
 to the reader (but remember to import `async_graphql::Object`). If you want the
 full source code and associated tests check out the [examples
-section](https://github.com/linera-io/linera-protocol/blob/{{#include
-../../../.git/modules/linera-protocol/HEAD}}/examples/counter/src/service.rs) on
-GitHub.
+section](https://github.com/linera-io/linera-protocol/blob/{{#include ../../../.git/modules/linera-protocol/HEAD}}/examples/counter/src/service.rs)
+on GitHub.

--- a/src/operators/devnets/compose.md
+++ b/src/operators/devnets/compose.md
@@ -1,0 +1,60 @@
+# Running devnets with Docker Compose
+
+The Linera validator reference implementation is a deployment on Kubernetes. In
+this section we'll be using Docker Compose to run a single node devnet.
+
+Docker Compose is a tool for defining and managing multi-container Docker
+applications. It allows you to describe the services, networks, and volumes of
+your application in a single YAML file (docker-compose.yml). With Docker
+Compose, you can easily start, stop, and manage all the containers in your
+application as a single unit using simple commands like docker-compose up and
+docker-compose down.
+
+## Installation
+
+This section covers everything you need to install to run a Linera network with
+Docker Compose.
+
+### Docker Compose Requirements
+
+To install Docker Compose see the
+[installing Docker Compose](https://docs.docker.com/compose/install/) section in
+the Docker docs.
+
+### Installing the Linera Toolchain
+
+To install the Linera Toolchain refer to the
+[installation section](../../developers/getting_started/installation.md#installing-from-github).
+
+You want to install thge toolchain from the GitHub, as you'll be using the
+repository to run the Docker Compose validator service.
+
+## Running with Docker Compose
+
+To run a local devnet with Docker Compose, navigate to the root of the
+`linera-protocol` repository and run:
+
+```bash
+cd docker && ./compose.sh
+```
+
+This will take some time as Docker images are built from the Linera source. When
+the service is ready, a temporary wallet and database is available under the
+`docker` subdirectory.
+
+Referencing these variables with the `linera` binary will enable you to interact
+with the devnet:
+
+```bash
+$ linera --wallet wallet.json --storage rocksdb:linera.db/ sync
+2024-06-07T14:19:32.751359Z  INFO linera: Synchronizing chain information
+2024-06-07T14:19:32.771842Z  INFO linera::client_context: Saved user chain states
+2024-06-07T14:19:32.771850Z  INFO linera: Synchronized chain information in 20 ms
+$ linera --wallet wallet.json --storage rocksdb:linera.db/ query-balance
+2024-06-07T14:19:36.958149Z  INFO linera: Evaluating the local balance of e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65 by staging execution of known incoming messages
+2024-06-07T14:19:36.959481Z  INFO linera: Balance obtained after 1 ms
+10.
+```
+
+The network is transient, so killing the script will perform a cleanup operation
+destroying wallets, storage and volumes associated with the network.


### PR DESCRIPTION
Preliminary docs for running a single-node network with Docker Compose. This is a starting point with more to come:
1. Running multiple validator networks
2. Joining existing networks

More work needs to be done in `linera-protocol` before the corresponding work can be done in `linera-documentation`, so issues for these will be created then.