### PR TITLE
Added microchains redirect

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -19,6 +19,7 @@ runnable = false
 
 [output.html.redirect]
 "/overview.html" = "/developers/core_concepts/overview.html"
+"/core_concepts/microchains.html" = "/developers/core_concepts/microchains.html"
 
 [output.linkcheck]
 


### PR DESCRIPTION
Google has Linera docs as a top result for 'microchains', however it links to the old page before the change adding operators. This PR adds a redirect fixing this.