### PR TITLE
External protocol for testnet is ClearText

### DIFF
--- a/src/operators/testnets/joining.md
+++ b/src/operators/testnets/joining.md
@@ -55,7 +55,7 @@ metrics_port = 21100
 internal_host = "proxy"
 internal_port = 20100
 [external_protocol]
-Grpc = "Tls"
+Grpc = "ClearText" # Depending on your load balancer you may need "Tls" here.
 [internal_protocol]
 Grpc = "ClearText"
 


### PR DESCRIPTION
If validators run a reverse proxy such as Nginx to perform Tls termination, the connection between Nginx and the proxy is on an internal network and therefore does not require Tls.