### PR TITLE
feat: Cookbook Onboard (AI Assistant) integration

### DIFF
--- a/custom.js
+++ b/custom.js
@@ -13,3 +13,26 @@ if (localAddrs.indexOf(document.location.hostname) === -1) {
     gtag('js', new Date());
     gtag('config', 'G-L0N9LPFQ32');
 }
+
+// Cookbook Onboard integration
+
+// The API Key is public, so we could just hardcode it here.
+const COOKBOOK_PUBLIC_API_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NmIzZTI0YTU1N2UxOGI0Yjk2MTE0ODYiLCJpYXQiOjE3MjMwNjQ5MDYsImV4cCI6MjAzODY0MDkwNn0.40K0d6-uER66iUF96Zm6l4f2PDpDPjuztJRpZ43QhV4';
+function initCookbook() {
+  let element = document.getElementById('__cookbook');
+  if (!element) {
+    element = document.createElement('div');
+    element.id = '__cookbook';
+    element.dataset.apiKey = COOKBOOK_PUBLIC_API_KEY;
+    document.body.appendChild(element);
+  }
+  let script = document.getElementById('__cookbook-script');
+  if (!script) {
+    script = document.createElement('script');
+    script.src = 'https://cdn.jsdelivr.net/npm/@cookbookdev/docsbot/dist/standalone/index.cjs.js';
+    script.id = '__cookbook-script';
+    script.defer = true;
+    document.body.appendChild(script);
+  }
+};
+initCookbook();


### PR DESCRIPTION
## Preview
https://docsbot-demo-git-linera-cookbookdev.vercel.app/developers/sdk.html

Cookbook's Ask Cookbook AI assistant and co-pilot is trained on all existing Linera resources (including source code, documentation, and website content). It is available as a standalone modal and can be embedded as a button on any page (recommended for technical documentation). It answers developer questions about building on Linera Protocol, serving as an enhanced and streamlined technical documentation search tool and a Solidity/Rust coding co-pilot.

Ask Cookbook AI can also access context from thousands of data sources indexed by Cookbook.dev, in addition to Linera-specific sources. This ensures it provides the best blockchain developer-focused answers of any chatbot on the market. Cookbook will assist in the tuning and calibration of the AI assistant to ensure the highest answer quality.

![image](https://github.com/user-attachments/assets/dd901ed7-b218-4b47-9aa4-b2f08e734eb0)