### PR TITLE
Fix state access typos in the doc. Add a note about naming convention.

### DIFF
--- a/src/developers/sdk/contract.md
+++ b/src/developers/sdk/contract.md
@@ -128,8 +128,8 @@ which is used to increment the counter by that value:
 
 ```rust,ignore
     async fn execute_operation(&mut self, operation: u64) {
-        let current = self.value.get();
-        self.value.set(current + operation);
+        let current = self.state.value.get();
+        self.state.value.set(current + operation);
     }
 ```
 

--- a/src/developers/sdk/creating_a_project.md
+++ b/src/developers/sdk/creating_a_project.md
@@ -20,6 +20,6 @@ files:
 - `src/service.rs`: the application's service, and the binary target for the
   service bytecode.
 
-> When writing Linera Application it is a convention to use your app's name as a
+> When writing Linera applications it is a convention to use your app's name as a
 > prefix for names of `trait`, `struct`, etc. Hence, in the following manual, we
 > will use `CounterContract`, `CounterService`, etc.

--- a/src/developers/sdk/creating_a_project.md
+++ b/src/developers/sdk/creating_a_project.md
@@ -19,3 +19,7 @@ files:
   contract bytecode;
 - `src/service.rs`: the application's service, and the binary target for the
   service bytecode.
+
+> When writing Linera Application it is a convention to use your app's name as a
+> prefix for names of `trait`, `struct`, etc. Hence, in the following manual, we
+> will use `CounterContract`, `CounterService`, etc.

--- a/src/developers/sdk/service.md
+++ b/src/developers/sdk/service.md
@@ -93,7 +93,7 @@ section, we use the following code:
     async fn handle_query(&mut self, request: Request) -> Response {
         let schema = Schema::build(
             // implemented in the next section
-            QueryRoot { value: *self.value.get() },
+            QueryRoot { value: *self.state.value.get() },
             // implemented in the next section
             MutationRoot {},
             EmptySubscription,


### PR DESCRIPTION
A follow-up to this would be https://github.com/linera-io/linera-protocol/issues/2577