### PR TITLE
Fix deploy validator command

### DIFF
--- a/src/operators/testnets/joining.md
+++ b/src/operators/testnets/joining.md
@@ -89,14 +89,14 @@ For example:
 ```bash
 $ git fetch origin
 $ git checkout -t origin/{{#include ../../../TESTNET_BRANCH}}
-$ ./scripts/deploy-validator.sh linera.mydomain.com
+$ cd scripts && ./deploy-validator.sh linera.mydomain.com
 ```
 
 The public key will be printed after the command has finished executing, for
 example:
 
 ```bash
-$ ./scripts/deploy-validator.sh linera.mydomain.com
+$ cd scripts && ./deploy-validator.sh linera.mydomain.com
 ...
 Public Key: 92f934525762a9ed99fcc3e3d3e35a825235dae133f2682b78fe22a742bac196
 ```


### PR DESCRIPTION
This may seem redundant, however running `deploy-validator` repeatedly failed unless called from within the `scripts` dir.