### PR TITLE
fix: Correct typos in documentation  

### DIFF
--- a/src/developers/sdk/service.md
+++ b/src/developers/sdk/service.md
@@ -58,7 +58,7 @@ linera_sdk::service!(CounterService);
 Next, we need to implement the `Service` trait for `CounterService` type. The
 first step is to define the `Service`'s associated type, which is the global
 parameters specified when the application is instantiated. In our case, the
-global paramters aren't used, so we can just specify the unit type:
+global parameters aren't used, so we can just specify the unit type:
 
 ```rust,ignore
 #[async_trait]

--- a/src/developers/sdk/testing.md
+++ b/src/developers/sdk/testing.md
@@ -52,7 +52,7 @@ mod tests {
         // Check that the state in memory is different from the state in storage
         assert_ne!(
             contract.state,
-            ApplicatonState::load(ViewStorageContext::from(runtime.key_value_store()))
+            ApplicationState::load(ViewStorageContext::from(runtime.key_value_store()))
         );
     }
 }

--- a/src/operators/testnets/joining.md
+++ b/src/operators/testnets/joining.md
@@ -84,10 +84,10 @@ example.com {
 ### ScyllaDB Configuration
 
 ScyllaDB is an open-source distributed NoSQL database built for high-performance
-and low-latency. Linera validators use ScyllaDB as their persistenct storage.
+and low-latency. Linera validators use ScyllaDB as their persistent storage.
 
 ScyllaDB may require kernel parameters to be modified in order to work.
-Specifically the the number of events allowed in asynchronous I/O contexts.
+Specifically the number of events allowed in asynchronous I/O contexts.
 
 To set this run:
 
@@ -181,7 +181,7 @@ For the next section, we'll be working out of the `docker` subdirectory in the
 ### Creating your Validator Configuration
 
 Validators are configured using a TOML file. You can use the following template
-to set up you own validator configuration:
+to set up your own validator configuration:
 
 ```toml
 server_config_path = "server.json"


### PR DESCRIPTION
The updates include:

- `testing.md`: Corrected a misspelling in `ApplicationState`.
- `service.md`: Fixed minor typographical error.
- `joining.md`: Standardized language for uniformity.

These revisions improve the overall clarity and accuracy of the documentation.
