### PR TITLE
typo Update contract.md

### DIFF
--- a/src/developers/sdk/contract.md
+++ b/src/developers/sdk/contract.md
@@ -18,7 +18,7 @@ pub trait Contract: WithContractAbi + ContractAbi + Sized {
     /// (e.g. an initial amount of tokens minted).
     type InstantiationArgument: Serialize + DeserializeOwned + Debug;
 
-    /// Creates a in-memory instance of the contract handler.
+    /// Creates an in-memory instance of the contract handler.
     async fn load(runtime: ContractRuntime<Self>) -> Self;
 
     /// Instantiates the application on the chain that created it.


### PR DESCRIPTION
There is a minor issue in the following sentence:

```rust
/// Creates a in-memory instance of the contract handler.
```

The phrase "a in-memory" should be corrected to "**an** in-memory," as the correct article for a word starting with a vowel sound ("in") is "**an**."

Corrected version:

```rust
/// Creates an in-memory instance of the contract handler.
```

Fixed.