### PR TITLE
Fix article usage in comment in src/developers/sdk/service.md

### DIFF
--- a/src/developers/sdk/service.md
+++ b/src/developers/sdk/service.md
@@ -18,7 +18,7 @@ pub trait Service: WithServiceAbi + ServiceAbi + Sized {
     /// Immutable parameters specific to this application.
     type Parameters: Serialize + DeserializeOwned + Send + Sync + Clone + Debug + 'static;
 
-    /// Creates a in-memory instance of the service handler.
+    /// Creates an in-memory instance of the service handler.
     async fn new(runtime: ServiceRuntime<Self>) -> Self;
 
     /// Executes a read-only query on the state of this application.


### PR DESCRIPTION
**Description:**

I found a minor issue in the comment section of the `src/developers/sdk/service.md` file. The phrase:

```rust
/// Creates a in-memory instance of the service handler.
```

contains an incorrect article usage. Since the word "in-memory" starts with a vowel sound, it should be preceded by "an" instead of "a".

The corrected sentence is:

```rust
/// Creates an in-memory instance of the service handler.
```

**Importance:**

While this is a small grammatical error, ensuring the correct use of articles improves the readability and clarity of the documentation. It is important to maintain high-quality documentation for better understanding and consistency, especially in developer-facing resources.