### PR TITLE
Typo Update compose.md

### DIFF
--- a/src/operators/devnets/compose.md
+++ b/src/operators/devnets/compose.md
@@ -18,7 +18,7 @@ For a more complete setup, consider using Kind as described
 This section covers everything you need to install to run a Linera network with
 Docker Compose.
 
-Note: This section was only tested under Linux.
+Note: This section was tested only on Linux.
 
 ### Docker Compose Requirements
 


### PR DESCRIPTION
**Description:**  
This pull request fixes a grammatical issue in the documentation under the "Installation" section of the guide for running devnets with Docker Compose.  

The original sentence:  
> "Note: This section was only tested under Linux."  

has been updated to:  
> **"Note: This section was tested only on Linux."**  

### Why this change is important:  
1. **Clarity and professionalism:** The previous phrasing, "only tested under Linux," was grammatically awkward. The updated version is more natural and adheres to standard English usage.  
2. **Improved readability:** Small grammatical improvements enhance the documentation's overall readability and professionalism, making it more accessible to users.  
3. **Consistency:** Correct grammar ensures that the documentation maintains a consistent level of quality, reflecting the project's attention to detail.  

### Changes made:  
- Corrected the phrasing in the documentation file under the "Installation" section.  

Thank you for considering this small but impactful change!