### PR TITLE
Typo Update glossary.md

### DIFF
--- a/src/appendix/glossary.md
+++ b/src/appendix/glossary.md
@@ -94,7 +94,7 @@
   bytecode which is instantiated as an application on the Linera Network.
 
 - **Public Chain**: A microchain with full BFT consensus with a strict set of
-  permissions relied on for the operation of the network,
+  permissions relied on for the operation of the network.
 
 - **Quorum**: A set of validators representing > ⅔ of the total stake. A quorum
   is required to create a certificate.


### PR DESCRIPTION
**Description:**  
This pull request corrects a punctuation error in the **Glossary** section of the documentation under the term **Public Chain**.  

### Issue:  
The original description ends with a comma (",") instead of a period ("."):  
> "A microchain with full BFT consensus with a strict set of permissions relied on for the operation of the network,"  

### Fix:  
The corrected version replaces the comma with a period to properly end the sentence:  
> **"A microchain with full BFT consensus with a strict set of permissions relied on for the operation of the network."**  

### Why this fix is important:  
1. **Grammatical accuracy:** Ending a sentence with a comma is incorrect and can confuse readers.  
2. **Professionalism:** Proper grammar and punctuation reflect attention to detail and enhance the overall quality of the documentation.  
3. **Improved readability:** Small corrections like this ensure that the documentation is clear and easy to understand.  

### Changes made:  
- Updated the punctuation in the definition of **Public Chain** in the Glossary file.  

Thank you for reviewing this minor but essential correction!