### PR TITLE
Typo Update state.md

### DIFF
--- a/src/developers/sdk/state.md
+++ b/src/developers/sdk/state.md
@@ -25,7 +25,7 @@ in general, we prefer to manage persistent data using the concept of "views":
 > framework, except that they are stored as a set of key-value pairs (instead of
 > a SQL row).
 
-In this case, the placeholder `Application` struct in `src/state.rs` should be
+In this case, the placeholder `Counter` struct in `src/state.rs` should be
 replaced by
 
 ```rust,ignore

--- a/src/developers/sdk/state.md
+++ b/src/developers/sdk/state.md
@@ -25,7 +25,7 @@ in general, we prefer to manage persistent data using the concept of "views":
 > framework, except that they are stored as a set of key-value pairs (instead of
 > a SQL row).
 
-In this case, the placeholder `Counter` struct in `src/state.rs` should be
+In this case, the struct in `src/state.rs` should be
 replaced by
 
 ```rust,ignore


### PR DESCRIPTION
#### Description of the Issue
In the documentation, there was a small typo in the following sentence:

> "the placeholder `Application` struct in `src/state.rs` should be replaced by"

The word "Application" should be replaced with "Counter" since the text describes the replacement of the `Application` struct with the `Counter` struct, not the other way around.

#### Fix Applied
The typo has been corrected as follows:

> "the placeholder `Counter` struct in `src/state.rs` should be replaced by"

#### Importance of the Fix
This is an important fix as the error could cause confusion for developers following the tutorial. The `Counter` struct is being introduced as the application's state structure, and mistakenly using `Application` could mislead the reader into thinking the `Application` struct is still relevant. This correction ensures clarity and helps maintain consistency with the rest of the documentation.
