### PR TITLE
Typo Update kind.md

### DIFF
--- a/src/operators/devnets/kind.md
+++ b/src/operators/devnets/kind.md
@@ -63,7 +63,7 @@ To run `kind` locally, you also need the following dependencies:
 ### Installing the Linera Toolchain
 
 To install the `Linera` toolchain, download the Linera source from
-[GitHub](https://github.com/linera-io/linera-protocol)):
+[GitHub](https://github.com/linera-io/linera-protocol):
 
 ```bash
 git clone https://github.com/linera-io/linera-protocol.git


### PR DESCRIPTION
#### Fixed Issue:

- In the **"Installing the Linera Toolchain"** section, there was an extra closing parenthesis in the sentence:
  - **"To install the `Linera` toolchain, download the Linera source from [GitHub](https://github.com/linera-io/linera-protocol)):"**
  - The corrected version is:
  - **"To install the `Linera` toolchain, download the Linera source from [GitHub](https://github.com/linera-io/linera-protocol):"**

#### Importance:

The extra parenthesis was a simple typographical error, but it could lead to confusion or cause formatting issues, especially for readers following the instructions. Removing the extra parenthesis ensures that the documentation appears professional and is free of potential distractions, providing a clearer and more accurate guide for users.

Please review and consider merging this fix. Thank you!
