### PR TITLE
Typo Update joining.md

### DIFF
--- a/src/operators/testnets/joining.md
+++ b/src/operators/testnets/joining.md
@@ -99,7 +99,7 @@ echo 1048576 > /proc/sys/fs/aio-max-nr
 
 > Note: This section was only tested under Linux.
 
-After downloading the `linera-protocol` repository, and checkout the testnet
+After downloading the `linera-protocol` repository, and checking out the testnet
 branch `{{#include ../../../TESTNET_BRANCH}}` you can run
 `scripts/deploy-validator.sh <hostname>` to deploy a Linera validator.
 


### PR DESCRIPTION
**Description:**

This pull request addresses a minor typo in the documentation. Specifically, the phrase:

"After downloading the linera-protocol repository, and checkout the testnet branch"

was incorrect. The word "checkout" should be changed to "check out" in this context, as "check out" is the correct verb form here.

**Importance of the Fix:**

This fix is important for clarity and correctness. While the original sentence may still be understandable, using "check out" instead of "checkout" ensures proper grammar and improves the overall professionalism of the documentation.

**Suggested Correction:**

```diff
- "After downloading the `linera-protocol` repository, and checkout the testnet branch"
+ "After downloading the `linera-protocol` repository, and checking out the testnet branch"
```

Thank you for reviewing the change!
**Love Linera!**