### PR TITLE
Clarify Language in Devnets Documentation

### DIFF
--- a/src/operators/devnets.md
+++ b/src/operators/devnets.md
@@ -3,6 +3,5 @@
 This section discusses how to deploy developer networks, aka "Devnets", for
 testing and development purposes.
 
-Devnets always start from a genesis configuration and an empty state. Validator
-nodes are usually operated in a single infrastructure for simplicity. Devnets do
+Devnets always start from a genesis configuration and an empty state. Validator nodes are typically run on a single infrastructure to simplify operations. Devnets do
 not handle real assets.


### PR DESCRIPTION
### Clarify Language in Devnets Documentation

**Problem**  
The sentence:  
> "Validator nodes are usually operated in a single infrastructure for simplicity"  
is clear but can be slightly improved for readability and precision. The phrase "usually operated" could be more concise, and "for simplicity" can be replaced with "to simplify operations," which better conveys intent.

**Solution**  
Rephrased the sentence to:  
> "Validator nodes are typically run on a single infrastructure to simplify operations."  

This revision makes the language more direct and professional while retaining the original meaning.

**Importance**  
Clear documentation is crucial for developer efficiency and understanding. Refining this sentence ensures that readers quickly grasp the intended meaning without ambiguity.
