### PR TITLE
Typos Update wallets.md

### DIFF
--- a/src/developers/core_concepts/wallets.md
+++ b/src/developers/core_concepts/wallets.md
@@ -76,7 +76,7 @@ linera wallet show
 
 The Chain ID which is in green text instead of white text is your default chain.
 
-To change the default chain for your wallet, user the `set-default` command:
+To change the default chain for your wallet, use the `set-default` command:
 
 ```bash
 linera wallet set-default <chain-id>
@@ -136,7 +136,7 @@ Finally, to add the chain to `wallet2` for the given unassigned key we use the
 
 #### Opening a Chain with Multiple Users
 
-The `open-chain` commands is a simplified version of `open-multi-owner-chain`,
+The `open-chain` command is a simplified version of `open-multi-owner-chain`,
 which gives you fine-grained control over the set and kinds of owners and rounds
 for the new chain, and the timeout settings for the rounds. E.g. this creates a
 chain with two owners and two multi-leader rounds.
@@ -158,7 +158,7 @@ For testing, rather than using `linera open-chain` and `linera assign` as above,
 it is often more convenient to pass the option `--extra-wallets N` to
 `linera net up`.
 
-This option will create create `N` additional user wallets and output Bash
+This option will create `N` additional user wallets and output Bash
 commands to define the environment variables `LINERA_{WALLET,STORAGE}_$I` where
 `I` ranges over `0..=N` (`I=0` being the wallet for the initial chains).
 


### PR DESCRIPTION
**Description:**

This pull request addresses the following typographical errors in the documentation:

1. **"user the `set-default` command"** has been corrected to "**use** the `set-default` command".  
   *Importance*: This correction ensures clarity and proper usage of the verb "use" in the context of executing a command, which is essential for accurate instructions.

2. **"The `open-chain` commands is a simplified version"** has been corrected to "**The `open-chain` command is a simplified version**".  
   *Importance*: This fix clarifies that the reference is to a singular command, not multiple commands, improving the accuracy of the sentence and avoiding confusion for readers.

3. **"create create `N` additional user wallets"** has been corrected to "**create `N` additional user wallets**".  
   *Importance*: Removing the redundant word "create" improves the readability of the sentence and ensures the instructions are concise.

By fixing these errors, the documentation is now clearer and more accurate, providing better guidance to developers and users interacting with the system.