### PR TITLE
Typo fix Update hello_linera.md

### DIFF
--- a/src/developers/getting_started/hello_linera.md
+++ b/src/developers/getting_started/hello_linera.md
@@ -127,7 +127,7 @@ linera service
 
 <!-- TODO: add graphiql image here -->
 
-Navigate to `http://localhost:8080` in your browser to access the GraphiQL, the
+Navigate to `http://localhost:8080` in your browser to access GraphiQL, the
 [GraphQL](https://graphql.org) IDE. We'll look at this in more detail in a
 [later section](../core_concepts/node_service.md#graphiql-ide); for now, list
 the applications deployed on your default chain e476… by running:


### PR DESCRIPTION
**Description:**  
This pull request corrects a small but important grammatical error in the documentation.  

### Issue  
The text in the "Hello, Linera" section currently reads:  
> _Navigate to `http://localhost:8080` in your browser to access the GraphiQL, the [[GraphQL](https://graphql.org/)](https://graphql.org) IDE._  

The definite article **"the"** before "GraphiQL" is unnecessary and incorrect, as "GraphiQL" is a proper noun and does not require an article in this context.  

### Fix  
The corrected sentence now reads:  
> _Navigate to `http://localhost:8080` in your browser to access GraphiQL, the [[GraphQL](https://graphql.org/)](https://graphql.org) IDE._  

### Importance of the Fix  
- **Clarity and Professionalism:** Maintaining grammatical accuracy ensures the documentation appears polished and professional, which reflects well on the project.  
- **User Experience:** Clear and error-free documentation enhances the reader's understanding and builds trust in the project's quality.  
