### PR TITLE
Fix spelling errors in documentation

### DIFF
--- a/src/appendix/videos.md
+++ b/src/appendix/videos.md
@@ -1,7 +1,7 @@
 # Videos
 
 We're constantly improving the SDK and creating new material. Below are some of
-our recent tutorial and presentation videos:
+our recent tutorials and presentations videos:
 
 ### [Rust on Linera: Spring 2024 Hackathon Kick-Off](https://www.youtube.com/watch?v=gVOHsS7d5qI)
 
@@ -34,6 +34,6 @@ empowerment in the new web ecosystem from Consensus 2024.
 
 For the latest videos and highlights, check out our
 [YouTube channel](https://www.youtube.com/@linera_io) and
-[Twitter Media](https://twitter.com/linera_io).
+[X Media](https://x.com/linera_io).
 
 _Happy viewing!_

--- a/src/developers/sdk.md
+++ b/src/developers/sdk.md
@@ -5,7 +5,7 @@ Linera SDK.
 
 We'll use a simple "counter" application as a running example.
 
-We'll focus on the back end of the application, which consists of two main
+We'll focus on the backend of the application, which consists of two main
 parts: a _smart contract_ and its GraphQL service.
 
 Both the contract and the service of an application are written in Rust using

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -25,8 +25,8 @@ To join our community and get involved in the development of the Linera
 ecosystem, check out our
 [GitHub repository](https://github.com/linera-io/linera-protocol), our
 [Website](https://linera.io), and find us on social media channels such as
-[Youtube](https://www.youtube.com/@linera_io),
-[Twitter](https://twitter.com/linera_io),
+[YouTube](https://www.youtube.com/@linera_io),
+[X](https://x.com/linera_io),
 [Telegram](https://t.me/linera_official), and
 [Discord](https://discord.gg/linera).
 


### PR DESCRIPTION
This pull request addresses several spelling and capitalization corrections in the documentation:

"Youtube" → "YouTube" to ensure correct brand capitalization.
"Twitter" → "X" in accordance with the platform's rebranding.
"back end" → "backend" for consistency in technical terminology.
"tutorial and presentation videos" → "tutorials and presentations" to maintain consistency in noun forms.