### PR TITLE
Typos Update ml.md

### DIFF
--- a/src/developers/experimental/ml.md
+++ b/src/developers/experimental/ml.md
@@ -129,10 +129,9 @@ perform inference in Wasm:
 
 ### Hardware Acceleration
 
-Although SIMD instructions _are_ supported by the service runtime, general
-purpose GPU hardware acceleration is
-[currently not supported](https://github.com/linera-io/linera-protocol/issues/1931).
-Therefore, performance in local model inference degraded for larger models.
+Although SIMD instructions _are_ supported by the service runtime, general-purpose GPU hardware acceleration is
+[not currently supported](https://github.com/linera-io/linera-protocol/issues/1931).
+Therefore, performance in local model inference degrades for larger models.
 
 ### On-Chain Models
 


### PR DESCRIPTION
In this update, a couple of minor changes have been made to improve the readability and style of the text:

1. The verb **"degraded"** in the sentence:
   > "performance in local model inference degraded for larger models."
   
   has been updated to **"degrades"** for better verb tense consistency:
   > "performance in local model inference degrades for larger models."

2. The phrase **"currently not supported"** in the section about hardware acceleration:
   > "general purpose GPU hardware acceleration is currently not supported."
   
   has been slightly rephrased to **"general-purpose GPU hardware acceleration is not currently supported."** This improves the readability by making the phrase flow more naturally.

These changes enhance clarity and ensure the document is consistent in its use of language.

Thanks for review!