### PR TITLE
Fix grammatical error Update ml.md

### DIFF
--- a/src/developers/experimental/ml.md
+++ b/src/developers/experimental/ml.md
@@ -132,7 +132,7 @@ perform inference in Wasm:
 Although SIMD instructions _are_ supported by the service runtime, general
 purpose GPU hardware acceleration is
 [currently not supported](https://github.com/linera-io/linera-protocol/issues/1931).
-Therefore, performance in local model inference degraded for larger models.
+Therefore, performance in local model inference is degraded for larger models.
 
 ### On-Chain Models
 


### PR DESCRIPTION
In the documentation, the sentence **"performance in local model inference degraded for larger models."** contained a grammatical error. The verb form was incorrect, missing the auxiliary verb "is," which is needed for proper sentence structure. The corrected version is:

**"performance in local model inference is degraded for larger models."**

This correction ensures the sentence is grammatically correct and maintains clarity in describing the impact of model size on performance.

Thanks for review!