### PR TITLE
`developers/getting_started/installation`: put `.local` in front of path

### DIFF
--- a/src/developers/getting_started/installation.md
+++ b/src/developers/getting_started/installation.md
@@ -38,7 +38,7 @@ Protoc. They can be installed as follows on Linux:
   - `curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.11/protoc-21.11-linux-x86_64.zip`
   - `unzip protoc-21.11-linux-x86_64.zip -d $HOME/.local`
   - If `~/.local` is not in your path, add it:
-    `export PATH="$PATH:$HOME/.local/bin"`
+    `export PATH="$HOME/.local/bin:$PATH"`
 
 - On certain Linux distributions, you may have to install development packages
   such as `g++`, `libclang-dev` and `libssl-dev`.


### PR DESCRIPTION
This ensures that even if the user already has `protoc` installed through other means, it's the freshly installed version they use.