### PR TITLE
fix: Fix incorrect syntax in struct declaration

### DIFF
--- a/src/developers/advanced_topics/contract_finalize.md
+++ b/src/developers/advanced_topics/contract_finalize.md
@@ -20,9 +20,9 @@ cross-application call with `Operation::EndSession` before the transaction ends.
 
 ```rust,ignore
 pub struct MyContract {
-    state: MyState;
-    runtime: ContractRuntime<Self>;
-    active_sessions: HashSet<ApplicationId>;
+    state: MyState,
+    runtime: ContractRuntime<Self>,
+    active_sessions: HashSet<ApplicationId>,
 }
 
 impl Contract for MyContract {


### PR DESCRIPTION
I noticed that in the struct definition for `MyContract`, a semicolon (`;`) was used instead of a comma (`,`). In Rust, when defining a struct, enumerations, or collections, commas should be used to separate the fields, not semicolons. This caused a syntax error and would prevent the code from compiling properly.

The change was simple: I replaced the semicolons with commas in the struct declaration to ensure it adheres to Rust's syntax rules.

This fix is important because it ensures that the code is syntactically correct and will compile without issues. The correct syntax improves readability and prevents potential confusion for others reading or maintaining the code.