### PR TITLE
fix typo Update hello_linera.md

### DIFF
--- a/src/developers/getting_started/hello_linera.md
+++ b/src/developers/getting_started/hello_linera.md
@@ -127,7 +127,7 @@ linera service
 
 <!-- TODO: add graphiql image here -->
 
-Navigate to `http://localhost:8080` in your browser to access the GraphiQL, the
+Navigate to `http://localhost:8080` in your browser to access GraphiQL, the
 [GraphQL](https://graphql.org) IDE. We'll look at this in more detail in a
 [later section](../core_concepts/node_service.md#graphiql-ide); for now, list
 the applications deployed on your default chain e476… by running:


### PR DESCRIPTION
The phrase "Navigate to `http://localhost:8080` in your browser to access the GraphiQL, the [[GraphQL](https://graphql.org/)](https://graphql.org) IDE." contains an unnecessary definite article *"the"* before *"GraphiQL"*. The correct version would be: *"Navigate to `http://localhost:8080` in your browser to access GraphiQL, the [[GraphQL](https://graphql.org/)](https://graphql.org) IDE."*

Corrected.