### PR TITLE
Improve clarity in read_events description for Ethereum interactions …

### DIFF
--- a/src/developers/advanced_topics/oracles.md
+++ b/src/developers/advanced_topics/oracles.md
@@ -27,8 +27,8 @@ provides functions to query an Ethereum node:
 - `get_balance` for accessing the balance of an Ethereum account at a specific
   block number.
 
-- `read_events` for reading the event from a specified Ethereum smart contract
-  from one block to a last block.
+- `read_events` for reading events from a specified Ethereum smart contract
+  from one block to the last block.
 
 - `non_executive_call` for executing a function in an Ethereum smart contract at
   a specific block, with the result not being included in the chain.


### PR DESCRIPTION
This update fixes a grammatical error and improves the clarity of the description for the `read_events` function in the Oracles and Ethereum section. Previously, the text read:

> - `read_events` for reading the event from a specified Ethereum smart contract from one block to a last block.

The corrected version is:

> - `read_events` for reading events from a specified Ethereum smart contract from one block to the last block.

**Key improvements:**
1. Changed "the event" to "events" to reflect the function's ability to process multiple events, ensuring accuracy.
2. Replaced "a last block" with "the last block" for grammatical correctness and better readability.
