### PR TITLE
docs: Fixed Typo in Developer Documentation Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ Then, open the URL as instructed.
 
 ## Formatting
 
-This repository is formatted with prettier. To install prettier run `npm install -g
+This repository is formatted with Prettier. To install prettier run `npm install -g
 prettier`. To use prettier run `prettier --write src`. The repository is automatically
 checked for formatting in CI.


### PR DESCRIPTION
The word "prettier" was originally written in lowercase, but since it's the name of the tool, it should be capitalized as "**Prettier**".