### PR TITLE
Improve clarity in the "Applications that Handle Assets" section

### DIFF
--- a/src/developers/advanced_topics/assets.md
+++ b/src/developers/advanced_topics/assets.md
@@ -16,7 +16,7 @@ Such an application should have a designated operation or message that causes it
 to close the chain: when that operation is executed, it should send back all
 remaining assets, and call the runtime's `close_chain` method.
 
-Once the chain is closed, owners can still create blocks rejecting messages.
+Once the chain is closed, owners can still create blocks to reject messages..
 That way, even assets that are in flight can be returned.
 
 The


### PR DESCRIPTION
# Description  
This change improves the phrasing of a sentence in the "Applications that Handle Assets" section to enhance readability and grammatical accuracy.  

The original sentence:  
> "Once the chain is closed, owners can still create blocks rejecting messages."  

has been updated to:  
> "Once the chain is closed, owners can still create blocks to reject messages."  

This adjustment ensures the text is clearer and aligns better with standard English usage, making the explanation easier to understand for readers.  
