### PR TITLE
docs: Improve phrasing in Linux testing note

### DIFF
--- a/src/operators/devnets/compose.md
+++ b/src/operators/devnets/compose.md
@@ -18,7 +18,7 @@ For a more complete setup, consider using Kind as described
 This section covers everything you need to install to run a Linera network with
 Docker Compose.
 
-Note: This section was tested only on Linux.
+Note: This section has been tested only on Linux.
 
 ### Docker Compose Requirements
 


### PR DESCRIPTION
### Description  
This update refines the phrasing in the Linux testing note for improved clarity and consistency with the documentation style.  

The original sentence:  
> "Note: This section was tested only on Linux."  

has been updated to:  
> "Note: This section has been tested only on Linux."  

The revised phrasing better reflects the current relevance of the testing status and aligns with standard documentation practices.