### PR TITLE
docs: typo fix Update compose.md

### DIFF
--- a/src/operators/devnets/compose.md
+++ b/src/operators/devnets/compose.md
@@ -44,7 +44,7 @@ cd docker && ./compose.sh
 ```
 
 This will take some time as Docker images are built from the Linera source. When
-the service is ready, a temporary wallet and database is available under the
+the service is ready, a temporary wallet and database are available under the
 `docker` subdirectory.
 
 Referencing these variables with the `linera` binary will enable you to interact


### PR DESCRIPTION
In the following sentence:

```text
a temporary wallet and database is available under the
```

The word "is" should be "are," as it refers to multiple items (wallet and database).

Corrected sentence:

```text
a temporary wallet and database are available under the
``` 

Fixed.