### PR TITLE
docs: typo fix Update contract.md

### DIFF
--- a/src/developers/sdk/contract.md
+++ b/src/developers/sdk/contract.md
@@ -96,7 +96,7 @@ provides more details on that.
 
 ## Instantiating our Application
 
-The first thing that happens when an application is created from a bytecode is
+The first thing that happens when an application is created from bytecode is
 that it is instantiated. This is done by calling the contract's
 `Contract::instantiate` method.
 


### PR DESCRIPTION
The word "a bytecode" is used incorrectly.
It would be more accurate to use "bytecode" without the article, as "bytecode" is an uncountable noun.