### PR TITLE
fix: Fix missing Result handling in getrandom registration example

### DIFF
--- a/src/developers/experimental/ml.md
+++ b/src/developers/experimental/ml.md
@@ -64,7 +64,7 @@ fn custom_getrandom(buf: &mut [u8]) -> Result<(), getrandom::Error> {
     Ok(())
 }
 
-getrandom::register_custom_getrandom!(custom_getrandom);
+getrandom::register_custom_getrandom!(custom_getrandom)?;
 ```
 
 This will enable `candle` and any other crates which rely on `getrandom` access


### PR DESCRIPTION
issue in the **Providing Randomness** section of the documentation. The example code for registering a custom RNG handler using `getrandom::register_custom_getrandom!` is missing the proper handling of the `Result` returned by this macro.  

the line:  

```rust
getrandom::register_custom_getrandom!(custom_getrandom);
```  

should be updated to:  

```rust
getrandom::register_custom_getrandom!(custom_getrandom)?;
```  

this ensures that any potential errors are properly propagated.
i've corrected this to align with best practices and avoid confusion for developers integrating this into their code.  

Thanks for maintaining this resource—it’s incredibly helpful! Let me know if you’d like further adjustments.