### PR TITLE
Activate linkcheck for external links

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -22,6 +22,8 @@ runnable = false
 "/core_concepts/microchains.html" = "/developers/core_concepts/microchains.html"
 
 [output.linkcheck]
+follow-web-links = true
+exclude = [ 'x\.com', 'crates\.io' ]
 
 [build]
 build-dir = "book"

--- a/src/developers/sdk/composition.md
+++ b/src/developers/sdk/composition.md
@@ -7,7 +7,7 @@ This section is about calling other applications using _cross-application
 calls_.
 
 Such calls happen on the same chain and are made with the
-[`ContractRuntime::call_application`](https://docs.rs/linera-sdk/latest/linera_sdk/struct.ContractRuntime.html#call_application)
+[`ContractRuntime::call_application`](https://docs.rs/linera-sdk/latest/linera_sdk/contract/type.ContractRuntime.html#call_application)
 method:
 
 ```rust,ignore

--- a/src/developers/sdk/messages.md
+++ b/src/developers/sdk/messages.md
@@ -10,14 +10,14 @@ may be different.
 
 For your application, you can specify any serializable type as the `Message`
 type in your `Contract` implementation. To send a message, use the
-[`ContractRuntime`](https://docs.rs/linera-sdk/latest/linera_sdk/struct.ContractRuntime.html)
-made available as an argument to the contract's [`Contract::load`] constructor.
-The runtime is usually stored inside the contract object, as we did when
-[writing the contract binary](./contract.md). We can then call
-[`ContractRuntime::prepare_message`](https://docs.rs/linera-sdk/latest/linera_sdk/struct.ContractRuntime.html#prepare_message)
-to start preparing a message, and then
-[`send_to`](https://docs.rs/linera-sdk/latest/linera_sdk/struct.MessageBuilder.html#send_to)
-to send it to a destination chain.
+[`ContractRuntime`](https://docs.rs/linera-sdk/latest/linera_sdk/contract/type.ContractRuntime.html)
+made available as an argument to the contract's
+[`Contract::load`](https://docs.rs/linera-sdk/latest/linera_sdk/trait.Contract.html#tymethod.load)
+constructor. The runtime is usually stored inside the contract object, as we did
+when [writing the contract binary](./contract.md). We can then call
+[`ContractRuntime::prepare_message`](https://docs.rs/linera-sdk/latest/linera_sdk/contract/type.ContractRuntime.html#prepare_message)
+to start preparing a message, and then `send_to` to send it to a destination
+chain.
 
 ```rust,ignore
     self.runtime


### PR DESCRIPTION
Enable the verification of external links -- except for `x.com` and `crates.io` which don't accept "robots".
