### PR TITLE
docs: fix typo in the description of oracle methods

### DIFF
--- a/src/developers/advanced_topics/oracles.md
+++ b/src/developers/advanced_topics/oracles.md
@@ -4,7 +4,7 @@
 > outside world that is not on-chain yet. One example is accessing the state of
 > an Ethereum smart contract from a Linera application.
 
-The contract runtime currently has two oracle methods:
+The contract runtime currently has three oracle methods:
 
 - `query_service` allows the contract to make a call to the application's own
   service code. Services can access some off-chain information, so these are not


### PR DESCRIPTION
I noticed a typo in the documentation. The sentence currently states:  

> The contract runtime currently has two oracle methods:  

However, three methods are listed: `query_service`, `http_post`, and `assert_before`.

I’ve updated the text to correctly reflect that there are **three** oracle methods:  
> The contract runtime currently has **three** oracle methods:  

