### PR TITLE
Fix incorrect variable error

### DIFF
--- a/src/developers/sdk/messages.md
+++ b/src/developers/sdk/messages.md
@@ -114,7 +114,7 @@ async fn execute_message(&mut self, message: Message) {
             source,
         } => {
             // ...
-            self.state.credit(receiver, amount).await;
+            self.state.credit(target, amount).await;
         }
         // ...
     }


### PR DESCRIPTION
In the `execute_message` block, the variable containing the target account is called `target` instead of `receiver` in the pattern matching.