### PR TITLE
avoid non-tested Rust quotes in several files

### DIFF
--- a/src/developers/advanced_topics/validators.md
+++ b/src/developers/advanced_topics/validators.md
@@ -85,7 +85,7 @@ balancer and the shared database are represented as a single entity but are
 meant to scale out in production.
 
 > For local testing during development, we currently use a single worker and
-> RocksDB as a database.
+> a testing in-memory service as a shared database.
 
 <!--
 ## Configuring Networks, Workers, and Proxies

--- a/src/developers/advanced_topics/validators.md
+++ b/src/developers/advanced_topics/validators.md
@@ -84,8 +84,8 @@ Note that the number of workers may vary for each validator. Both the load
 balancer and the shared database are represented as a single entity but are
 meant to scale out in production.
 
-> For local testing during development, we currently use a single worker and
-> a testing in-memory service as a shared database.
+> For local testing during development, we currently use a single worker and a
+> testing in-memory service as a shared database.
 
 <!--
 ## Configuring Networks, Workers, and Proxies

--- a/src/developers/sdk/abi.md
+++ b/src/developers/sdk/abi.md
@@ -43,14 +43,8 @@ All these types must implement the `Serialize`, `DeserializeOwned`, `Send`,
 
 In our example, we would like to change our `Operation` to `u64`, like so:
 
-```rust
-# extern crate linera_base;
-# use linera_base::abi::ContractAbi;
-# struct CounterAbi;
-impl ContractAbi for CounterAbi {
-    type Operation = u64;
-    type Response = ();
-}
+```rust,ignore
+{{#include ../../../linera-protocol/examples/counter/src/lib.rs:contract_abi}}
 ```
 
 ## Service ABI
@@ -65,16 +59,21 @@ application:
 {{#include ../../../linera-protocol/linera-base/src/abi.rs:service_abi}}
 ```
 
-For our Counter example, we'll be using GraphQL to query our application so our
-`ServiceAbi` should reflect that:
+For our `Counter` example, we'll be using GraphQL to query our application so
+our `ServiceAbi` should reflect that:
 
-```rust
-# extern crate linera_base;
-# extern crate async_graphql;
-# use linera_base::abi::ServiceAbi;
-# struct CounterAbi;
-impl ServiceAbi for CounterAbi {
-    type Query = async_graphql::Request;
-    type QueryResponse = async_graphql::Response;
-}
+```rust,ignore
+use async_graphql::{Request, Response};
+
+{{#include ../../../linera-protocol/examples/counter/src/lib.rs:service_abi}}
 ```
+
+## References
+
+- The full trait definition of `Abi` can be found
+  [here](https://github.com/linera-io/linera-protocol/blob/{{#include
+  ../../../.git/modules/linera-protocol/HEAD}}/linera-base/src/abi.rs).
+
+- The full `Counter` example application can be found
+  [here](https://github.com/linera-io/linera-protocol/blob/{{#include
+  ../../../.git/modules/linera-protocol/HEAD}}/examples/counter).

--- a/src/developers/sdk/composition.md
+++ b/src/developers/sdk/composition.md
@@ -6,22 +6,18 @@ always handled by the _same_ application on the target chain.
 This section is about calling other applications using _cross-application
 calls_.
 
-Such calls happen on the same chain and are made with the
-[`ContractRuntime::call_application`](https://docs.rs/linera-sdk/latest/linera_sdk/contract/type.ContractRuntime.html#call_application)
-method:
+Such calls happen on the same chain and are made with the helper method
+[`ContractRuntime::call_application`](https://docs.rs/linera-sdk/latest/linera_sdk/contract/type.ContractRuntime.html#call_application):
 
 ```rust,ignore
-pub fn call_application<A: ContractAbi + Send>(
-    &mut self,
-    authenticated: bool,
-    application: ApplicationId<A>,
-    call: &A::Operation,
-) -> A::Response {
+{{#include ../../../linera-protocol/linera-sdk/src/contract/runtime.rs:call_application}}
 ```
 
 The `authenticated` argument specifies whether the callee is allowed to perform
-actions that require authentication on behalf of the signer of the original
-block that caused this call.
+actions that require authentication either
+
+- on behalf of the signer of the original block that caused this call, or
+- on behalf of the calling application.
 
 The `application` argument is the callee's application ID, and `A` is the
 callee's ABI.
@@ -94,10 +90,16 @@ indirectly by signing her block. The crowd-funding application now makes a note
 in its application state on Bob's chain that Carol has pledged 10 Pugecoin
 tokens.
 
-For the complete code please take a look at the
+# References
+
+For the complete code, please take a look at the
 [`crowd-funding`](https://github.com/linera-io/linera-protocol/blob/{{#include
 ../../../.git/modules/linera-protocol/HEAD}}/examples/crowd-funding/src/contract.rs)
 and the
 [`fungible`](https://github.com/linera-io/linera-protocol/blob/{{#include
 ../../../.git/modules/linera-protocol/HEAD}}/examples/fungible/src/contract.rs)
 application contracts in the `examples` folder in `linera-protocol`.
+
+The implementation of the Runtime made available to contracts is defined in
+[this file](https://github.com/linera-io/linera-protocol/blob/{{#include
+../../../.git/modules/linera-protocol/HEAD}}/linera-sdk/src/contract/runtime.rs).

--- a/src/developers/sdk/messages.md
+++ b/src/developers/sdk/messages.md
@@ -62,61 +62,25 @@ sends a `Credit` message to the recipient's chain:
 
 ```rust,ignore
 async fn execute_operation(&mut self, operation: Self::Operation) -> Self::Response {
-    match operation {
-        // ...
-        Operation::Transfer {
-            owner,
-            amount,
-            target_account,
-        } => {
-            self.check_account_authentication(owner)?;
-            self.state.debit(owner, amount).await?;
-            self.finish_transfer_to_account(amount, target_account, owner)
-                .await;
-            FungibleResponse::Ok
+        match operation {
+{{#include ../../../linera-protocol/examples/fungible/src/contract.rs:execute_operation_transfer}}
+            // ...
         }
-        // ...
-    }
 }
+```
 
-async fn finish_transfer_to_account(
-    &mut self,
-    amount: Amount,
-    target_account: Account,
-    source: AccountOwner,
-) {
-    if target_account.chain_id == self.runtime.chain_id() {
-        self.state.credit(target_account.owner, amount).await;
-    } else {
-        let message = Message::Credit {
-            target: target_account.owner,
-            amount,
-            source,
-        };
-        self.runtime
-            .prepare_message(message)
-            .with_authentication()
-            .with_tracking()
-            .send_to(target_account.chain_id);
-    }
-}
+```rust,ignore
+{{#include ../../../linera-protocol/examples/fungible/src/contract.rs:finish_transfer_to_account}}
 ```
 
 On the recipient's chain, `execute_message` is called, which increases their
 account balance.
 
 ```rust,ignore
-async fn execute_message(&mut self, message: Message) {
-    match message {
-        Message::Credit {
-            amount,
-            target,
-            source,
-        } => {
+    async fn execute_message(&mut self, message: Message) {
+        match message {
+{{#include ../../../linera-protocol/examples/fungible/src/contract.rs:execute_message_credit}}
             // ...
-            self.state.credit(target, amount).await;
         }
-        // ...
     }
-}
 ```

--- a/src/developers/sdk/service.md
+++ b/src/developers/sdk/service.md
@@ -97,9 +97,8 @@ serialized operation to increment the counter by the provided `value`:
 {{#include ../../../linera-protocol/examples/counter/src/service.rs:mutation}}
 ```
 
-We haven't included the imports in the above code; they are left as an exercise
-to the reader (but remember to import `async_graphql::Object`). If you want the
-full source code and associated tests check out the [examples
+We haven't included the imports in the above code. If you want the full source
+code and associated tests check out the [examples
 section](https://github.com/linera-io/linera-protocol/blob/{{#include
 ../../../.git/modules/linera-protocol/HEAD}}/examples/counter/src/service.rs) on
 GitHub.

--- a/src/developers/sdk/state.md
+++ b/src/developers/sdk/state.md
@@ -8,7 +8,7 @@ The `struct` which defines your application's state can be found in
 
 While we could use a plain data-structure for the entire application state:
 
-```rust,ignore
+```rust
 struct Counter {
   value: u64
 }
@@ -27,7 +27,14 @@ in general, we prefer to manage persistent data using the concept of "views":
 
 In this case, the struct in `src/state.rs` should be replaced by
 
-```rust,ignore
+```rust
+# extern crate linera_sdk;
+# extern crate async_graphql;
+# use linera_sdk::base::*;
+# use linera_sdk::*;
+# use std::collections::HashSet;
+# use linera_sdk::views::{linera_views, RegisterView, RootView, ViewStorageContext};
+# use crate::linera_sdk::views::View as _;
 /// The application state.
 #[derive(RootView, async_graphql::SimpleObject)]
 #[view(context = "ViewStorageContext")]

--- a/src/developers/sdk/testing.md
+++ b/src/developers/sdk/testing.md
@@ -30,7 +30,7 @@ runtimes, and can be configured to return specific values for different tests.
 A simple unit test is shown below, which tests if the method `execute_operation`
 method changes the application state of the `Counter` application.
 
-```rust
+```rust,ignore
 {{#include ../../../linera-protocol/examples/counter/src/contract.rs:counter_test}}
 ```
 
@@ -48,6 +48,6 @@ the application.
 A simple integration test that execution a block containing an operation for the
 `Counter` application is shown below.
 
-```rust
+```rust,ignore
 {{#include ../../../linera-protocol/examples/counter/tests/single_chain.rs:counter_integration_test}}
 ```


### PR DESCRIPTION
Make sure Rust quotes use anchors or are fully type-checked in many of the files.

fixes #176 
fixes #177
fixes #178
fixes #179
fixes #180
fixes #181
fixes #183 