### PR TITLE
Update deploy.md - Correct the file name in the command to match the …

### DIFF
--- a/src/developers/backend/deploy.md
+++ b/src/developers/backend/deploy.md
@@ -19,7 +19,7 @@ application while also specifying:
 
 ```bash
 linera publish-and-create \
-  target/wasm32-unknown-unknown/release/my-counter_{contract,service}.wasm \
+  target/wasm32-unknown-unknown/release/my_counter_{contract,service}.wasm \
   --json-argument "42"
 ```
 
@@ -42,7 +42,7 @@ specifying:
 
 ```bash
 linera publish-and-create \
-  target/wasm32-unknown-unknown/release/my-counter_{contract,service}.wasm \
+  target/wasm32-unknown-unknown/release/my_counter_{contract,service}.wasm \
   --json-argument "42"
 ```
 


### PR DESCRIPTION
…example.

If you want to try to publish the Counter application with default settings, the wasm file name must be "my_counter***" not "my-counter***" corresponding to the file name that was built in target/wasm32-unknown-unknown/release/