### PR TITLE
Update testnet name from Babbage to Conway

### DIFF
--- a/RELEASE_BRANCH
+++ b/RELEASE_BRANCH
@@ -1,1 +1,1 @@
-testnet_babbage
+testnet_conway

--- a/RELEASE_DOMAIN
+++ b/RELEASE_DOMAIN
@@ -1,1 +1,1 @@
-testnet-babbage
+testnet-conway

--- a/TESTNET_BRANCH
+++ b/TESTNET_BRANCH
@@ -1,1 +1,1 @@
-testnet_babbage
+testnet_conway

--- a/TESTNET_DOMAIN
+++ b/TESTNET_DOMAIN
@@ -1,1 +1,1 @@
-testnet-babbage
+testnet-conway

--- a/src/developers/frontend/interactivity.md
+++ b/src/developers/frontend/interactivity.md
@@ -30,7 +30,7 @@ Now the module `@linera/client` is available for import in your module:
 ## Referring to the counter app
 
 We'll need the application ID of the counter app deployed on our network of
-choice. This tutorial uses Testnet Babbage, and the following application ID
+choice. This tutorial uses Testnet Conway, and the following application ID
 refers to a counter app published there:
 
 ```javascript
@@ -56,13 +56,13 @@ await linera.default();
 
 If you have a wallet file available, you can use the `linera.Wallet.fromJson`
 function to create a `linera.Wallet` from it. However, for the purposes of the
-tutorial, we will connect to the Testnet Babbage faucet and create a new wallet
+tutorial, we will connect to the Testnet Conway faucet and create a new wallet
 with a fresh chain owning some tokens. We will also update our `#chain-id`
 element to let the user know the ID of their new chain.
 
 ```javascript
 const faucet = await new linera.Faucet(
-  'https://faucet.testnet-babbage.linera.net',
+  'https://faucet.testnet-conway.linera.net',
 );
 const wallet = await faucet.createWallet();
 const client = await new linera.Client(wallet);

--- a/src/developers/frontend/interactivity.md
+++ b/src/developers/frontend/interactivity.md
@@ -30,7 +30,7 @@ Now the module `@linera/client` is available for import in your module:
 ## Referring to the counter app
 
 We'll need the application ID of the counter app deployed on our network of
-choice. This tutorial uses Testnet Conway, and the following application ID
+choice. This tutorial uses Testnet, and the following application ID
 refers to a counter app published there:
 
 ```javascript
@@ -56,13 +56,13 @@ await linera.default();
 
 If you have a wallet file available, you can use the `linera.Wallet.fromJson`
 function to create a `linera.Wallet` from it. However, for the purposes of the
-tutorial, we will connect to the Testnet Conway faucet and create a new wallet
+tutorial, we will connect to the Testnet faucet and create a new wallet
 with a fresh chain owning some tokens. We will also update our `#chain-id`
 element to let the user know the ID of their new chain.
 
 ```javascript
 const faucet = await new linera.Faucet(
-  'https://faucet.testnet-conway.linera.net',
+  'https://faucet.{{#include ../../../TESTNET_DOMAIN}}.linera.net',
 );
 const wallet = await faucet.createWallet();
 const client = await new linera.Client(wallet);

--- a/src/protocol/roadmap.md
+++ b/src/protocol/roadmap.md
@@ -50,7 +50,7 @@ Codename: Archimedes
 
 - Onboarding of 20+ external validators
 
-## Testnet #2 (planned Apr 2025)
+## Testnet #2 (released Apr 2025)
 
 Codename: Babbage
 
@@ -78,7 +78,9 @@ Codename: Babbage
 
 - Support for resizing workers offline
 
-## Testnet #3
+## Testnet #3 (planned Sep 2025)
+
+Codename: Conway
 
 **SDK**
 


### PR DESCRIPTION
## Summary
- Updated testnet name from Babbage to Conway throughout the documentation

## Changes
- Modified testnet references to reflect the new Conway testnet name
- Ensures documentation is consistent with the current testnet deployment

🤖 Generated with [Claude Code](https://claude.ai/code)