### PR TITLE
Update validator deployment docs to reflect new default remote Docker images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,25 @@
 book
 *.iml
 .idea/
+
+# emacs
+*~
+
+# vim
+*.swp
+
+# idea
+*.iml
+.idea/
+
+# VSCode
+.vscode/
+.direnv/
+
+# Cursor
+.cursor
+
+# Claude
+.claude
+CLAUDE.md
+.serena

--- a/src/operators/testnets/debugging.md
+++ b/src/operators/testnets/debugging.md
@@ -37,6 +37,7 @@ the `--local-build` flag.
 
 The Docker Compose manifest looks for the `LINERA_IMAGE` environment variable.
 If not set, it defaults to:
+
 ```
 us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest
 ```
@@ -44,15 +45,19 @@ us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest
 If you encounter pull access issues:
 
 1. **Check network connectivity** to the registry:
+
    ```bash
    docker pull us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest
    ```
 
 2. **Build locally instead** if registry access fails:
+
    ```bash
    scripts/deploy-validator.sh <host> <email> --local-build
    ```
+
    Or manually:
+
    ```bash
    docker build --build-arg git_commit="$(git rev-parse --short HEAD)" -f docker/Dockerfile . -t linera
    export LINERA_IMAGE=linera

--- a/src/operators/testnets/debugging.md
+++ b/src/operators/testnets/debugging.md
@@ -31,16 +31,37 @@ required.
 
 ### `pull access denied`
 
-When deploying a validator you can either build the Docker image yourself or use
-a pre-built remote image provided by the Linera team.
+When deploying a validator, the system uses pre-built Docker images from the
+official registry by default. You can also build the Docker image yourself using
+the `--local-build` flag.
 
-The Docker Compose manifest looks for the `LINERA_IMAGE` environment variable
-which is usually set by the default script. If it is not found, it defaults to
-the value `linera`, which is assumed to exist as an image locally.
+The Docker Compose manifest looks for the `LINERA_IMAGE` environment variable.
+If not set, it defaults to:
+```
+us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest
+```
 
-To resolve this issue either explicitly specify the `LINERA_IMAGE` or ensure
-that the
-[image is built locally](manual-installation.md#building-the-linera-docker-image).
+If you encounter pull access issues:
+
+1. **Check network connectivity** to the registry:
+   ```bash
+   docker pull us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest
+   ```
+
+2. **Build locally instead** if registry access fails:
+   ```bash
+   scripts/deploy-validator.sh <host> <email> --local-build
+   ```
+   Or manually:
+   ```bash
+   docker build --build-arg git_commit="$(git rev-parse --short HEAD)" -f docker/Dockerfile . -t linera
+   export LINERA_IMAGE=linera
+   ```
+
+3. **Use a custom image** by setting `LINERA_IMAGE`:
+   ```bash
+   export LINERA_IMAGE=my-registry/my-image:my-tag
+   ```
 
 ### `Access denied to genesis.json`
 

--- a/src/operators/testnets/debugging.md
+++ b/src/operators/testnets/debugging.md
@@ -39,7 +39,7 @@ The Docker Compose manifest looks for the `LINERA_IMAGE` environment variable.
 If not set, it defaults to:
 
 ```
-us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest
+us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera::latest
 ```
 
 If you encounter pull access issues:

--- a/src/operators/testnets/debugging.md
+++ b/src/operators/testnets/debugging.md
@@ -38,8 +38,8 @@ the `--local-build` flag.
 The Docker Compose manifest looks for the `LINERA_IMAGE` environment variable.
 If not set, it defaults to:
 
-```
-us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera::latest
+```text
+us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest
 ```
 
 If you encounter pull access issues:

--- a/src/operators/testnets/manual-installation.md
+++ b/src/operators/testnets/manual-installation.md
@@ -100,16 +100,41 @@ the chosen host name for onboarding in the next epoch.
 > Note: Before being included in the next epoch, validator nodes will receive no
 > traffic from existing users.
 
-### Building the Linera Docker image
+### Using the Linera Docker image
 
-To build the Linera Docker image, run the following command from the root of the
-`linera-protocol` repository:
+#### Option 1: Use Pre-built Image (Recommended)
+
+By default, the Linera Docker images are available from the official registry.
+The images are tagged based on the branch:
+- `latest` for the main branch
+- `{branch}_release` for release branches
+
+The default image path is:
+```
+us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:{tag}
+```
+
+You can pull the image directly:
+```bash
+docker pull us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest
+```
+
+#### Option 2: Build Locally
+
+If you prefer to build the Linera Docker image locally, run the following command
+from the root of the `linera-protocol` repository:
 
 ```bash
 docker build --build-arg git_commit="$(git rev-parse --short HEAD)" -f docker/Dockerfile . -t linera
 ```
 
 This can take several minutes.
+
+When using docker-compose, set the `LINERA_IMAGE` environment variable to use
+your locally built image:
+```bash
+export LINERA_IMAGE=linera
+```
 
 ### Configuring Caddy for SSL/TLS
 
@@ -137,7 +162,11 @@ server configuration is available at `docker/server.json`, the validator can be
 started by running from inside the `docker` directory:
 
 ```bash
+# Using the default pre-built image
 cd docker && docker compose up -d
+
+# Or, if you built the image locally
+cd docker && LINERA_IMAGE=linera docker compose up -d
 ```
 
 This will run the Docker Compose deployment in a detached mode, which includes:

--- a/src/operators/testnets/manual-installation.md
+++ b/src/operators/testnets/manual-installation.md
@@ -106,23 +106,26 @@ the chosen host name for onboarding in the next epoch.
 
 By default, the Linera Docker images are available from the official registry.
 The images are tagged based on the branch:
+
 - `latest` for the main branch
 - `{branch}_release` for release branches
 
 The default image path is:
+
 ```
 us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:{tag}
 ```
 
 You can pull the image directly:
+
 ```bash
 docker pull us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:latest
 ```
 
 #### Option 2: Build Locally
 
-If you prefer to build the Linera Docker image locally, run the following command
-from the root of the `linera-protocol` repository:
+If you prefer to build the Linera Docker image locally, run the following
+command from the root of the `linera-protocol` repository:
 
 ```bash
 docker build --build-arg git_commit="$(git rev-parse --short HEAD)" -f docker/Dockerfile . -t linera
@@ -132,6 +135,7 @@ This can take several minutes.
 
 When using docker-compose, set the `LINERA_IMAGE` environment variable to use
 your locally built image:
+
 ```bash
 export LINERA_IMAGE=linera
 ```

--- a/src/operators/testnets/manual-installation.md
+++ b/src/operators/testnets/manual-installation.md
@@ -113,7 +113,7 @@ The images are tagged based on the branch:
 The default image path is:
 
 ```
-us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:{tag}
+us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera::\{tag\}
 ```
 
 You can pull the image directly:

--- a/src/operators/testnets/manual-installation.md
+++ b/src/operators/testnets/manual-installation.md
@@ -112,8 +112,8 @@ The images are tagged based on the branch:
 
 The default image path is:
 
-```
-us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera::\{tag\}
+```text
+us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera:{tag}
 ```
 
 You can pull the image directly:

--- a/src/operators/testnets/one-click.md
+++ b/src/operators/testnets/one-click.md
@@ -9,7 +9,7 @@ For example:
 ```bash
 $ git fetch origin
 $ git checkout -t origin/{{#include ../../../RELEASE_BRANCH}}
-$ scripts/deploy-validator.sh linera.mydomain.com admin@mydomain.com --remote-image
+$ scripts/deploy-validator.sh linera.mydomain.com admin@mydomain.com
 ```
 
 The email address is required for ACME/Let's Encrypt SSL certificate generation.
@@ -38,8 +38,8 @@ The deploy script accepts the following arguments:
 
 And the following optional flags:
 
-- `--remote-image`: Use the pre-built Docker image from the official registry
-  (recommended)
+- `--local-build`: Build Docker image locally instead of using registry image
+- `--remote-image`: Explicitly use remote Docker image from registry (deprecated, now default)
 - `--skip-genesis`: Skip downloading the genesis configuration (use existing)
 - `--force-genesis`: Force re-download of genesis configuration even if it
   exists
@@ -53,8 +53,8 @@ And the following optional flags:
 - `--verbose` or `-v`: Enable verbose output
 - `--help` or `-h`: Show help message
 
-> Note: If you don't specify `--remote-image`, the script will build the Docker
-> image locally from source.
+> Note: By default, the script uses the pre-built Docker image from the official
+> registry. Use `--local-build` if you want to build from source.
 
 ### Environment Variables
 
@@ -79,22 +79,25 @@ For example:
 
 ```bash
 # Deploy with more shards
-NUM_SHARDS=8 scripts/deploy-validator.sh validator.example.com admin@example.com --remote-image
+NUM_SHARDS=8 scripts/deploy-validator.sh validator.example.com admin@example.com
 
 # Deploy with XFS partition for optimal ScyllaDB performance
-scripts/deploy-validator.sh validator.example.com admin@example.com --remote-image \
+scripts/deploy-validator.sh validator.example.com admin@example.com \
   --xfs-path /mnt/xfs-scylla --cache-size 8G
 
 # Deploy with custom image tag (for testing)
-scripts/deploy-validator.sh validator.example.com admin@example.com --remote-image \
+scripts/deploy-validator.sh validator.example.com admin@example.com \
   --custom-tag devnet_2025_08_21
+
+# Build Docker image locally instead of using registry
+scripts/deploy-validator.sh validator.example.com admin@example.com --local-build
 ```
 
 The public key and account key will be printed after the command has finished
 executing, for example:
 
 ```bash
-$ scripts/deploy-validator.sh linera.mydomain.com admin@mydomain.com --remote-image
+$ scripts/deploy-validator.sh linera.mydomain.com admin@mydomain.com
 ...
 Public Key: 02a580bbda90f0ab10f015422d450b3e873166703af05abd77d8880852a3504e4d,009b2ecc5d39645e81ff01cfe4ceeca5ec207d822762f43b35ef77b2367666a7f8
 ```

--- a/src/operators/testnets/one-click.md
+++ b/src/operators/testnets/one-click.md
@@ -39,7 +39,8 @@ The deploy script accepts the following arguments:
 And the following optional flags:
 
 - `--local-build`: Build Docker image locally instead of using registry image
-- `--remote-image`: Explicitly use remote Docker image from registry (deprecated, now default)
+- `--remote-image`: Explicitly use remote Docker image from registry
+  (deprecated, now default)
 - `--skip-genesis`: Skip downloading the genesis configuration (use existing)
 - `--force-genesis`: Force re-download of genesis configuration even if it
   exists


### PR DESCRIPTION
## Summary

This PR updates the validator deployment documentation to reflect changes made in the `deploy-validator.sh` script that now uses remote Docker images by default instead of building locally.

## Changes

### Key Updates:
- **Default behavior change**: Validators now use pre-built Docker images from `us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera` by default
- **New `--local-build` flag**: Added for explicitly building Docker images locally
- **Deprecated `--remote-image` flag**: This is now the default behavior

### Files Modified:
1. **`src/operators/testnets/one-click.md`**:
   - Removed `--remote-image` from all examples since it's now the default
   - Updated documentation to explain the new default behavior
   - Added example showing how to use `--local-build` for local builds

2. **`src/operators/testnets/manual-installation.md`**:
   - Restructured Docker image section with pre-built images as Option 1 (Recommended)
   - Added details about registry paths and image tagging (`latest` for main, `{branch}_release` for branches)
   - Updated docker-compose commands to show both pre-built and local build options

3. **`src/operators/testnets/debugging.md`**:
   - Updated the "pull access denied" troubleshooting section
   - Added steps for checking registry connectivity
   - Included fallback instructions for building locally

## Impact

These documentation updates ensure that:
- New validators will use official pre-built images by default, making deployments faster and more consistent
- The documentation accurately reflects the current deployment process
- Users still have the option to build locally when needed
- Troubleshooting guides are updated for the new default behavior

## Related PR

This documentation update corresponds to changes in the deployment script in the `linera-protocol` repository.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>