### PR TITLE
Document source link checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,18 @@ git submodule update --init
 
 To discard local changes to the submodule (the equivalent of `git checkout -f HEAD` for
 files), use `git submodule update`.
+
+## Checking source links
+
+The published site is built from the `linera-protocol` submodule. When changing
+the mdBook source path or the GitHub edit URL template in that submodule, verify
+that generated "Edit" links point to repository paths without `..` segments.
+
+For example, a page generated from `docs/protocol/overview.md` should link to:
+
+```text
+https://github.com/linera-io/linera-protocol/edit/main/docs/protocol/overview.md
+```
+
+Before publishing, check at least one top-level page and one nested developer
+page so broken source-path mappings are caught before deployment.


### PR DESCRIPTION
## Summary
- document how the published site maps back to the linera-protocol submodule
- add a quick checklist for verifying generated Edit links before publishing
- include an example of the expected source URL without `..` path segments

## Verification
- ran git diff --check
- confirmed the README includes the expected linera-protocol edit URL example

Related to #258